### PR TITLE
Enable `gzip` option of package "request" if necessary

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -113,7 +113,6 @@ function filter_request_headers(headers) {
         }
     }
 
-    ret_headers['Accept-Encoding'] = 'deflate';
     return ret_headers;
 }
 


### PR DESCRIPTION
`Content-Type: gzip` is not automatically detected and is incurrectly handled
by package "request" if option `gzip` is not set to `true` before sending the request.
This fixes https://github.com/Unblocker/Unblock-Youku/issues/491
The drawback is that responseBody sent back to proxy client will be uncompressed and bigger.
( responseBody from target url will be gzipped if `Accept-Encoding` from proxy client
contains gzip and the target server supports gzipped response body. )

And `content-length` should be `Buffer.byteLength(str)` instead of `str.length`.
