### PR TITLE
Change to enforce `Accept-Encoding` to `indentity`

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -171,7 +171,6 @@ function http_req_handler(client_request, client_response) {
 
     function handle_proxy_response_data(response, payload) {
         var filtered_headers = server_utils.filter_response_headers(response.headers);
-        filtered_headers['content-length'] = payload.length;
         client_response.writeHead(response.statusCode, filtered_headers);
         client_response.end(payload);
     }

--- a/server/utils.js
+++ b/server/utils.js
@@ -113,7 +113,7 @@ function filter_request_headers(headers) {
         }
     }
 
-    ret_headers['Accept-Encoding'] = 'deflate';
+    ret_headers['Accept-Encoding'] = 'identity';
     return ret_headers;
 }
 


### PR DESCRIPTION
Reponse with `content-encoding: delfate` is not correctly handled by package "request".
Enforce using `identity` fixes https://github.com/Unblocker/Unblock-Youku/issues/491.
The drawback is that both responseBody from target url and responseBody sent to proxy client
will be uncompressed and bigger.
